### PR TITLE
add tesseract 3.04 support

### DIFF
--- a/tesseract.go
+++ b/tesseract.go
@@ -32,7 +32,11 @@ func getTesseractCmd() (tess tesseractCmd, e error) {
 		tess = tesseract0303{version: v, commandPath: commandPath}
 		return
 	}
-	e = fmt.Errorf("No tesseract version is found, supporting 3.02~ and 3.03~")
+	if regexp.MustCompile("^3.04").Match([]byte(v)) {
+		tess = tesseract0304{version: v, commandPath: commandPath}
+		return
+	}
+	e = fmt.Errorf("No tesseract version is found, supporting 3.02~, 3.03~ and 3.04~")
 	return
 }
 func lookPath() (commandPath string, e error) {

--- a/tesseract0304.go
+++ b/tesseract0304.go
@@ -1,0 +1,60 @@
+package gosseract
+
+import "fmt"
+import "os"
+import "os/exec"
+import "bytes"
+import "io/ioutil"
+
+type tesseract0304 struct {
+	version        string
+	resultFilePath string
+	commandPath    string
+}
+
+func (t tesseract0304) Version() string {
+	return t.version
+}
+
+func (t tesseract0304) Execute(params []string) (res string, e error) {
+	// command args
+	var args []string
+	// Register source file
+	args = append(args, params[0])
+	// generate result file path
+	t.resultFilePath, e = generateTmpFile()
+	if e != nil {
+		return
+	}
+	// Register result file
+	args = append(args, t.resultFilePath)
+	// Register digest file
+	if len(params) > 1 {
+		args = append(args, params[1])
+	}
+
+	// prepare command
+	cmd := exec.Command(TESSERACT, args...)
+	// execute
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if e = cmd.Run(); e != nil {
+		e = fmt.Errorf(stderr.String())
+		return
+	}
+	// read result
+	res, e = t.readResult()
+	return
+}
+
+func (t tesseract0304) readResult() (res string, e error) {
+	fpath := t.resultFilePath + outFILEEXTENSION
+	file, e := os.OpenFile(fpath, 1, 1)
+	if e != nil {
+		return
+	}
+	buffer, _ := ioutil.ReadFile(file.Name())
+	res = string(buffer)
+	os.Remove(file.Name())
+	return
+}


### PR DESCRIPTION
The tesseract changelog didn't look dramatic and tests run here.

It also worked for my small test project.

I just copied the code for the other supported versions, but you may want to take a different approach?