### PR TITLE
Fixing simple typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ import (
 )
 
 func main() {
-    // This is the simlest way :)
+    // This is the simplest way :)
     out := gosseract.Must(gosseract.Params{
 			Src:       "your/img/file.png",
 			Languages: "eng+heb",


### PR DESCRIPTION
Just a quick fix to a typo in the README.  "simlest" to "simplest"