### PR TITLE
Added a return and support for Tesseract 3.05~

### DIFF
--- a/tesseract.go
+++ b/tesseract.go
@@ -36,7 +36,11 @@ func getTesseractCmd() (tess tesseractCmd, e error) {
 		tess = tesseract0304{version: v, commandPath: commandPath}
 		return
 	}
-	e = fmt.Errorf("No tesseract version is found, supporting 3.02~, 3.03~ and 3.04~")
+	if regexp.MustCompile("^3.05").Match([]byte(v)) {
+		tess = tesseract0305{version: v, commandPath: commandPath}
+		return
+	}
+	e = fmt.Errorf("No tesseract version is found, supporting 3.02~, 3.03~, 3.04~ and 3.05~")
 	return
 }
 func lookPath() (commandPath string, e error) {

--- a/tesseract.go
+++ b/tesseract.go
@@ -51,18 +51,21 @@ func version() (v string, e error) {
 	matches := exp.FindStringSubmatch(v)
 	if len(matches) < 2 {
 		e = fmt.Errorf("tesseract version not found: response is `%s`", v)
+		return
 	}
 	v = matches[1]
 	return
 }
 func execTesseractCommandWithStderr(opt string) (res string, e error) {
 	cmd := exec.Command(TESSERACT, opt)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if e = cmd.Run(); e != nil {
 		return
 	}
-	res = stderr.String()
+	res = stdout.String() + stderr.String()
 	return
 }
 func generateTmpFile() (fname string, e error) {

--- a/tesseract0305.go
+++ b/tesseract0305.go
@@ -1,0 +1,60 @@
+package gosseract
+
+import "fmt"
+import "os"
+import "os/exec"
+import "bytes"
+import "io/ioutil"
+
+type tesseract0305 struct {
+	version        string
+	resultFilePath string
+	commandPath    string
+}
+
+func (t tesseract0305) Version() string {
+	return t.version
+}
+
+func (t tesseract0305) Execute(params []string) (res string, e error) {
+	// command args
+	var args []string
+	// Register source file
+	args = append(args, params[0])
+	// generate result file path
+	t.resultFilePath, e = generateTmpFile()
+	if e != nil {
+		return
+	}
+	// Register result file
+	args = append(args, t.resultFilePath)
+	// Register digest file
+	if len(params) > 1 {
+		args = append(args, params[1])
+	}
+
+	// prepare command
+	cmd := exec.Command(TESSERACT, args...)
+	// execute
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if e = cmd.Run(); e != nil {
+		e = fmt.Errorf(stderr.String())
+		return
+	}
+	// read result
+	res, e = t.readResult()
+	return
+}
+
+func (t tesseract0305) readResult() (res string, e error) {
+	fpath := t.resultFilePath + outFILEEXTENSION
+	file, e := os.OpenFile(fpath, 1, 1)
+	if e != nil {
+		return
+	}
+	buffer, _ := ioutil.ReadFile(file.Name())
+	res = string(buffer)
+	os.Remove(file.Name())
+	return
+}


### PR DESCRIPTION
I'm not sure about the return of `func execTesseractCommandWithStderr`, but it shouldn't work without returning Stdout. Stderr is empty if `cmd.Run`s err isn't `nil`.