### PR TITLE
Fixed bug with unremoved temporary files that cause "file" leak

### DIFF
--- a/client.go
+++ b/client.go
@@ -10,6 +10,8 @@ type Client struct {
 	tesseract tesseractCmd
 	source    path
 	digest    path
+	// If the generated PNG source file needs to be deleted
+	needsdelete bool
 	Error     error
 }
 type path struct {
@@ -60,7 +62,7 @@ func (c *Client) Image(img image.Image) *Client {
 	}
 	defer f.Close()
 	png.Encode(f, img)
-	// TODO: delete created file after
+	c.needsdelete = true
 	c.source = path{f.Name()}
 	return c
 }
@@ -72,6 +74,10 @@ func (c *Client) Out() (out string, e error) {
 	}
 	// TODO: validation to call execute
 	out, e = c.execute()
+	if c.needsdelete {
+		os.Remove(c.source.value)
+		c.needsdelete = false
+	}
 	return
 }
 

--- a/tesseract0302.go
+++ b/tesseract0302.go
@@ -44,6 +44,7 @@ func (t tesseract0302) Execute(params []string) (res string, e error) {
 	}
 	// read result
 	res, e = t.readResult()
+	os.Remove(t.resultFilePath)
 	return
 }
 func (t tesseract0302) readResult() (res string, e error) {

--- a/tesseract0303.go
+++ b/tesseract0303.go
@@ -44,6 +44,7 @@ func (t tesseract0303) Execute(params []string) (res string, e error) {
 	}
 	// read result
 	res, e = t.readResult()
+	os.Remove(t.resultFilePath)
 	return
 }
 

--- a/tesseract0304.go
+++ b/tesseract0304.go
@@ -44,6 +44,7 @@ func (t tesseract0304) Execute(params []string) (res string, e error) {
 	}
 	// read result
 	res, e = t.readResult()
+	os.Remove(t.resultFilePath)
 	return
 }
 

--- a/tesseract0305.go
+++ b/tesseract0305.go
@@ -44,6 +44,7 @@ func (t tesseract0305) Execute(params []string) (res string, e error) {
 	}
 	// read result
 	res, e = t.readResult()
+	os.Remove(t.resultFilePath)
 	return
 }
 


### PR DESCRIPTION
Hey there, thanks for making this library. I use `Image(image.Image)` to do OCR roughly every 5 seconds, this creates a lot of waste in /tmp (which is large because you generate png files for each input)

I managed to fix two subtle file leaks here and removed a TODO :)

I appreciate your work on this library.