### PR TITLE
add CXXFLAGS for compiling with ubuntu

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,5 +1,6 @@
 package gosseract
 
+// #cgo CXXFLAGS: -std=c++11
 // #if __FreeBSD__ >= 10
 // #cgo LDFLAGS: -L/usr/local/lib -llept -ltesseract
 // #else


### PR DESCRIPTION
Trying to use gosseract with ubuntu 16.04 and tesseract4 i need this CXXFLAGS for fixing 

    #error This file requires compiler and library support for the ISO C++ 2011 standard

Maybe this should be inside an if, like the BSD clause? 