### PR TITLE
Add functions for HOCR and setting config file

### DIFF
--- a/tessbridge.cpp
+++ b/tessbridge.cpp
@@ -24,6 +24,13 @@ void Init(TessBaseAPI a, char* tessdataprefix, char* languages) {
   api->Init(tessdataprefix, languages);
 }
 
+void InitConfig(TessBaseAPI a, char* tessdataprefix, char* languages, char* config) {
+  char *configs[]={config};
+  int configs_size = 1;
+  tesseract::TessBaseAPI * api = (tesseract::TessBaseAPI*)a;
+  api->Init(tessdataprefix, languages, tesseract::OEM_DEFAULT, configs, configs_size, NULL, NULL, false);
+}
+
 void SetVariable(TessBaseAPI a, char* name, char* value) {
   tesseract::TessBaseAPI * api = (tesseract::TessBaseAPI*)a;
   api->SetVariable(name, value);
@@ -49,6 +56,11 @@ int GetPageSegMode(TessBaseAPI a) {
 char* UTF8Text(TessBaseAPI a) {
   tesseract::TessBaseAPI * api = (tesseract::TessBaseAPI*)a;
   return api->GetUTF8Text();
+}
+
+char* HOCRText(TessBaseAPI a) {
+  tesseract::TessBaseAPI * api = (tesseract::TessBaseAPI*)a;
+  return api->GetHOCRText(0);
 }
 
 const char* Version(TessBaseAPI a) {

--- a/tessbridge.h
+++ b/tessbridge.h
@@ -6,11 +6,13 @@ typedef void* TessBaseAPI;
 TessBaseAPI Create(void);
 void Free(TessBaseAPI);
 void Init(TessBaseAPI, char*, char*);
+void InitConfig(TessBaseAPI, char*, char*, char*);
 void SetVariable(TessBaseAPI, char*, char*);
 void SetImage(TessBaseAPI, char*);
 void SetPageSegMode(TessBaseAPI, int);
 int GetPageSegMode(TessBaseAPI);
 char* UTF8Text(TessBaseAPI);
+char* HOCRText(TessBaseAPI);
 const char* Version(TessBaseAPI);
 
 #ifdef __cplusplus


### PR DESCRIPTION
I figured out getting HOCR data and setting a config file from issue #107. 

This addition is backward compatible with existing code. 

Added functions are
```
Client.SetConfig(string) //Sets config file path to be used in Client.Init
C.InitConfig() //Calls correct TessBaseAPI.Init() to use config file.
C.HOCRText() //Return HOCR data in a string.
```

Hope you are able to include these changes in the repo and that others find it useful. 