### PR TITLE
Fixes for memory leak in pix images, unnecessary reinitialization, and api additions

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -16,6 +16,13 @@ func TestVersion(t *testing.T) {
 	Expect(t, version).Match("[0-9]{1}.[0-9]{2}(.[0-9a-z]*)?")
 }
 
+func TestClearPersistentCache(t *testing.T) {
+	client := NewClient()
+	defer client.Close()
+	client.init()
+	ClearPersistentCache()
+}
+
 func TestNewClient(t *testing.T) {
 	client := NewClient()
 	defer client.Close()
@@ -33,8 +40,20 @@ func TestClient_SetImage(t *testing.T) {
 	client.SetPageSegMode(PSM_SINGLE_BLOCK)
 
 	text, err := client.Text()
+	if client.pixImage == nil {
+		t.Errorf("could not set image")
+	}
 	Expect(t, err).ToBe(nil)
 	Expect(t, text).ToBe("Hello, World!")
+
+	client.SetImage("./test/data/001-helloworld.png")
+	if client.pixImage != nil {
+		t.Errorf("could not destory pix image")
+	}
+
+	client.SetImage("somewhere/fake/fakeimage.png")
+	_, err = client.Text()
+	Expect(t, err).Not().ToBe(nil)
 
 }
 
@@ -53,8 +72,15 @@ func TestClient_SetImageFromBytes(t *testing.T) {
 	client.SetPageSegMode(PSM_SINGLE_BLOCK)
 
 	text, err := client.Text()
+	if client.pixImage == nil {
+		t.Errorf("could not set image")
+	}
 	Expect(t, err).ToBe(nil)
 	Expect(t, text).ToBe("Hello, World!")
+	client.SetImageFromBytes(content)
+	if client.pixImage != nil {
+		t.Errorf("could not destory pix image")
+	}
 }
 
 func TestClient_SetWhitelist(t *testing.T) {

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -5,8 +5,17 @@ import "testing"
 func BenchmarkClient_Text(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		client := NewClient()
-		client.SetImage("./test/data/001-gosseract.png")
+		client.SetImage("./test/data/001-helloworld.png")
 		client.Text()
 		client.Close()
 	}
+}
+
+func BenchmarkClient_Text2(b *testing.B) {
+	client := NewClient()
+	for i := 0; i < b.N; i++ {
+		client.SetImage("./test/data/001-helloworld.png")
+		client.Text()
+	}
+	client.Close()
 }

--- a/client.go
+++ b/client.go
@@ -227,6 +227,8 @@ func (client *Client) prepare() error {
 			img := C.SetImage(client.api, imagepath)
 			client.pixImage = img
 		}
+	} else {
+		C.SetPixImage(client.api, client.pixImage)
 	}
 
 	for key, value := range client.Variables {

--- a/client.go
+++ b/client.go
@@ -95,6 +95,10 @@ func (client *Client) Close() (err error) {
 	// }()
 	C.Clear(client.api)
 	C.Free(client.api)
+	if client.pixImage != nil {
+		C.DestroyPixImage(client.pixImage)
+		client.pixImage = nil
+	}
 	return err
 }
 

--- a/tessbridge.cpp
+++ b/tessbridge.cpp
@@ -68,6 +68,12 @@ PixImage SetImageFromBuffer(TessBaseAPI a, unsigned char* data, int size) {
   return (void*)image;
 }
 
+void SetPixImage(TessBaseAPI a, PixImage pix) {
+  tesseract::TessBaseAPI * api = (tesseract::TessBaseAPI*)a;
+  Pix *image = (Pix*) pix;
+  api->SetImage(image);
+}
+
 void SetPageSegMode(TessBaseAPI a, int m) {
   tesseract::TessBaseAPI * api = (tesseract::TessBaseAPI*)a;
   tesseract::PageSegMode mode = (tesseract::PageSegMode)m;

--- a/tessbridge.cpp
+++ b/tessbridge.cpp
@@ -54,6 +54,8 @@ PixImage SetImage(TessBaseAPI a, char* imagepath) {
   tesseract::TessBaseAPI * api = (tesseract::TessBaseAPI*)a;
   Pix *image = pixRead(imagepath);
   api->SetImage(image);
+  if(api->GetSourceYResolution() < 70)
+    api->SetSourceResolution(70);
   return (void*)image;
 }
 
@@ -61,6 +63,8 @@ PixImage SetImageFromBuffer(TessBaseAPI a, unsigned char* data, int size) {
   tesseract::TessBaseAPI * api = (tesseract::TessBaseAPI*)a;
   Pix *image = pixReadMem(data, (size_t)size);
   api->SetImage(image);
+  if(api->GetSourceYResolution() < 70)
+    api->SetSourceResolution(70);
   return (void*)image;
 }
 

--- a/tessbridge.cpp
+++ b/tessbridge.cpp
@@ -19,6 +19,16 @@ void Free(TessBaseAPI a) {
   delete api;
 }
 
+void Clear(TessBaseAPI a) {
+  tesseract::TessBaseAPI * api = (tesseract::TessBaseAPI*)a;
+  api->Clear();
+}
+
+void ClearPersistentCache(TessBaseAPI a) {
+  tesseract::TessBaseAPI * api = (tesseract::TessBaseAPI*)a;
+  api->ClearPersistentCache();
+}
+
 int Init(TessBaseAPI a, char* tessdataprefix, char* languages) {
   tesseract::TessBaseAPI * api = (tesseract::TessBaseAPI*)a;
   return api->Init(tessdataprefix, languages);
@@ -40,16 +50,18 @@ bool SetVariable(TessBaseAPI a, char* name, char* value) {
   return api->SetVariable(name, value);
 }
 
-void SetImage(TessBaseAPI a, char* imagepath) {
+PixImage SetImage(TessBaseAPI a, char* imagepath) {
   tesseract::TessBaseAPI * api = (tesseract::TessBaseAPI*)a;
   Pix *image = pixRead(imagepath);
   api->SetImage(image);
+  return (void*)image;
 }
 
-void SetImageFromBuffer(TessBaseAPI a, unsigned char* data, int size) {
+PixImage SetImageFromBuffer(TessBaseAPI a, unsigned char* data, int size) {
   tesseract::TessBaseAPI * api = (tesseract::TessBaseAPI*)a;
   Pix *image = pixReadMem(data, (size_t)size);
   api->SetImage(image);
+  return (void*)image;
 }
 
 void SetPageSegMode(TessBaseAPI a, int m) {
@@ -77,4 +89,9 @@ const char* Version(TessBaseAPI a) {
   tesseract::TessBaseAPI * api = (tesseract::TessBaseAPI*)a;
   const char* v = api->Version();
   return v;
+}
+
+void DestroyPixImage(PixImage pix){
+  Pix *img = (Pix*) pix;
+  pixDestroy(&img);
 }

--- a/tessbridge.h
+++ b/tessbridge.h
@@ -13,6 +13,7 @@ int Init(TessBaseAPI, char*, char*, char*);
 bool SetVariable(TessBaseAPI, char*, char*);
 PixImage SetImage(TessBaseAPI, char*);
 PixImage SetImageFromBuffer(TessBaseAPI, unsigned char*, int);
+void SetPixImage(TessBaseAPI a, PixImage pix);
 void SetPageSegMode(TessBaseAPI, int);
 int GetPageSegMode(TessBaseAPI);
 char* UTF8Text(TessBaseAPI);

--- a/tessbridge.h
+++ b/tessbridge.h
@@ -3,17 +3,23 @@ extern "C" {
 #endif
 
 typedef void* TessBaseAPI;
+typedef void* PixImage;
+
 TessBaseAPI Create(void);
 void Free(TessBaseAPI);
+void Clear(TessBaseAPI);
+void ClearPersistentCache(TessBaseAPI);
 int Init(TessBaseAPI, char*, char*, char*);
 bool SetVariable(TessBaseAPI, char*, char*);
-void SetImage(TessBaseAPI, char*);
-void SetImageFromBuffer(TessBaseAPI, unsigned char*, int);
+PixImage SetImage(TessBaseAPI, char*);
+PixImage SetImageFromBuffer(TessBaseAPI, unsigned char*, int);
 void SetPageSegMode(TessBaseAPI, int);
 int GetPageSegMode(TessBaseAPI);
 char* UTF8Text(TessBaseAPI);
 char* HOCRText(TessBaseAPI);
 const char* Version(TessBaseAPI);
+
+void DestroyPixImage(PixImage pix);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This should fix #124 in regards to deleting pix images created.
Additions in the Tesseract API include:
tesseract::TessBaseAPI::ClearPersistentCache
tesseract::TessBaseAPI::Clear

Alias for pixDestory -- DestoryPixImage

I also added some checks so that the client is not always reinitializing a client that has already been initialized, it causes performance degradation as seen in the benchmark if reused. The client will also no longer call the c API to set the image on every text or HOCRText call if a pix image has already been set and was not called previously.


Benchmark reusing a client:
oos: darwin
goarch: amd64
pkg: github.com/otiai10/gosseract
BenchmarkClient_Text-4                 5         213477008 ns/op
BenchmarkClient_Text2-4               30          39615045 ns/op
PASS
ok      github.com/otiai10/gosseract    4.680s

