### PR TITLE
Remove stderr capture.

### DIFF
--- a/client.go
+++ b/client.go
@@ -250,12 +250,10 @@ func (client *Client) init() error {
 	}
 	defer C.free(unsafe.Pointer(configfile))
 
-	errbuf := [512]C.char{}
-	res := C.Init(client.api, nil, languages, configfile, &errbuf[0])
-	msg := C.GoString(&errbuf[0])
+	res := C.Init(client.api, nil, languages, configfile)
 
 	if res != 0 {
-		return fmt.Errorf("failed to initialize TessBaseAPI with code %d: %s", res, msg)
+		return fmt.Errorf("failed to initialize TessBaseAPI with code %d", res)
 	}
 
 	if err := client.setVariablesToInitializedAPI(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/otiai10/gosseract/v2
 
 require github.com/otiai10/mint v1.3.0
+
+go 1.13

--- a/tessbridge.cpp
+++ b/tessbridge.cpp
@@ -6,8 +6,6 @@
 #include <tesseract/baseapi.h>
 #endif
 
-#include <stdio.h>
-#include <unistd.h>
 #include "tessbridge.h"
 
 TessBaseAPI Create() {
@@ -36,34 +34,15 @@ int Init(TessBaseAPI a, char* tessdataprefix, char* languages) {
     return api->Init(tessdataprefix, languages);
 }
 
-int Init(TessBaseAPI a, char* tessdataprefix, char* languages, char* configfilepath, char* errbuf) {
+int Init(TessBaseAPI a, char* tessdataprefix, char* languages, char* configfilepath) {
     tesseract::TessBaseAPI* api = (tesseract::TessBaseAPI*)a;
-
-    // {{{ Redirect STDERR to given buffer
-    fflush(stderr);
-    int original_stderr;
-    original_stderr = dup(STDERR_FILENO);
-    (void)freopen("/dev/null", "a", stderr);
-    setbuf(stderr, errbuf);
-    // }}}
-
-    int ret;
     if (configfilepath != NULL) {
         char* configs[] = {configfilepath};
         int configs_size = 1;
-        ret = api->Init(tessdataprefix, languages, tesseract::OEM_DEFAULT, configs, configs_size, NULL, NULL, false);
+        return api->Init(tessdataprefix, languages, tesseract::OEM_DEFAULT, configs, configs_size, NULL, NULL, false);
     } else {
-        ret = api->Init(tessdataprefix, languages);
+        return api->Init(tessdataprefix, languages);
     }
-
-    // {{{ Restore default stderr
-    (void)freopen("/dev/null", "a", stderr);
-    dup2(original_stderr, STDERR_FILENO);
-    close(original_stderr);
-    setbuf(stderr, NULL);
-    // }}}
-
-    return ret;
 }
 
 bool SetVariable(TessBaseAPI a, char* name, char* value) {

--- a/tessbridge.h
+++ b/tessbridge.h
@@ -22,7 +22,7 @@ TessBaseAPI Create(void);
 void Free(TessBaseAPI);
 void Clear(TessBaseAPI);
 void ClearPersistentCache(TessBaseAPI);
-int Init(TessBaseAPI, char*, char*, char*, char*);
+int Init(TessBaseAPI, char*, char*, char*);
 struct bounding_boxes* GetBoundingBoxes(TessBaseAPI, int);
 struct bounding_boxes* GetBoundingBoxesVerbose(TessBaseAPI);
 bool SetVariable(TessBaseAPI, char*, char*);


### PR DESCRIPTION
The attempt to capture CGo stderr was closing stderr for the process
which was causing the process to lose all logs after an init call to the
tesseract client.