### PR TITLE
tesseract 5.x does not seem to default to eng anymore, fix #238 and #239

### DIFF
--- a/client.go
+++ b/client.go
@@ -77,6 +77,7 @@ func NewClient() *Client {
 		Variables:  map[SettableVariable]string{},
 		Trim:       true,
 		shouldInit: true,
+		Languages:  []string{"eng"},
 	}
 	return client
 }


### PR DESCRIPTION
This segmentation fault seems to be raised because tesseract 5.0.0 and above does not default to English anymore. It can be easily fixed by initializing the Languages slice.

This should fix #238 and fix #239.