### PR TITLE
add a finalizer to close the client

### DIFF
--- a/client.go
+++ b/client.go
@@ -16,6 +16,7 @@ import (
 	"image"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"unsafe"
 )
@@ -79,6 +80,8 @@ func NewClient() *Client {
 		shouldInit: true,
 		Languages:  []string{"eng"},
 	}
+	// set a finalizer to close the client when it's unused and not closed by the user
+	runtime.SetFinalizer(client, (*Client).Close)
 	return client
 }
 
@@ -95,6 +98,8 @@ func (client *Client) Close() (err error) {
 		C.DestroyPixImage(client.pixImage)
 		client.pixImage = nil
 	}
+	// no need for a finalizer anymore
+	runtime.SetFinalizer(client, nil)
 	return err
 }
 


### PR DESCRIPTION
If the developer forgets to call the close method after creating the client, it will cause a memory leak.

To avoid this, I refer to the method in [os.File](https://go.dev/src/os/file_windows.go#L62). By adding a finalizer, the `Close` method will be called when the client is unreachable and the developer haven't call the `Close` method neither.

## Test

client.go

```go
// NewClient construct new Client. It's due to caller to Close this client.
func NewClient() *Client {
	client := &Client{
		api:        C.Create(),
		Variables:  map[SettableVariable]string{},
		Trim:       true,
		shouldInit: true,
		Languages:  []string{"eng"},
	}
	// set a finalizer to close the client when it's unused and not closed by the user
	runtime.SetFinalizer(client, (*Client).Close)
	return client
}

// Close frees allocated API. This MUST be called for ANY client constructed by "NewClient" function.
func (client *Client) Close() (err error) {
	// defer func() {
	// 	if e := recover(); e != nil {
	// 		err = fmt.Errorf("%v", e)
	// 	}
	// }()
	fmt.Println("Closed")
	C.Clear(client.api)
	C.Free(client.api)
	if client.pixImage != nil {
		C.DestroyPixImage(client.pixImage)
		client.pixImage = nil
	}
	// no need for a finalizer anymore
	runtime.SetFinalizer(client, nil)
	return err
}
```

test code

```go
func main() {
	runGgosseract()
	runtime.GC() // run a garbage collection
	time.Sleep(2 * time.Second)
	// see "Close" before "exit"
	fmt.Println("exit")
}

func runGgosseract() {
	client := gosseract.NewClient()
	client.SetImage("path/to/image.png")
	text, _ := client.Text()
	fmt.Println(text)
}
```