### PR TITLE
fix 'leptonica/allheaders.h' file not found on macOS (brew)

### DIFF
--- a/preprocessflags_darwin.go
+++ b/preprocessflags_darwin.go
@@ -1,0 +1,7 @@
+package gosseract
+
+// #cgo CXXFLAGS: -std=c++0x
+// #cgo CPPFLAGS: -I/opt/homebrew/include -I/usr/local/include
+// #cgo CPPFLAGS: -Wno-unused-result
+// #cgo LDFLAGS: -L/opt/homebrew/lib -L/usr/local/lib -lleptonica -ltesseract
+import "C"

--- a/preprocessflags_x.go
+++ b/preprocessflags_x.go
@@ -1,3 +1,5 @@
+//go:build !darwin
+
 package gosseract
 
 // #cgo CXXFLAGS: -std=c++0x


### PR DESCRIPTION
```
BEFORE:
tessbridge.cpp:5:10: fatal error: 'leptonica/allheaders.h' file not found
FAIL	github.com/otiai10/gosseract/v2 [build failed]
FAIL
AFTER:
go test ./...
ok  	github.com/otiai10/gosseract/v2	0.921s
``