### PR TITLE
add errors when PixImage is nil

### DIFF
--- a/client.go
+++ b/client.go
@@ -119,6 +119,10 @@ func (client *Client) SetImage(imagepath string) error {
 	defer C.free(unsafe.Pointer(p))
 
 	img := C.CreatePixImageByFilePath(p)
+	if img == nil {
+		return fmt.Errorf("failed to create PixImage from file path: %s", imagepath)
+	}
+
 	client.pixImage = img
 
 	return nil
@@ -140,6 +144,10 @@ func (client *Client) SetImageFromBytes(data []byte) error {
 	}
 
 	img := C.CreatePixImageFromBytes((*C.uchar)(unsafe.Pointer(&data[0])), C.int(len(data)))
+	if img == nil {
+		return fmt.Errorf("failed to create PixImage from bytes")
+	}
+
 	client.pixImage = img
 
 	return nil

--- a/client.go
+++ b/client.go
@@ -145,7 +145,7 @@ func (client *Client) SetImageFromBytes(data []byte) error {
 
 	img := C.CreatePixImageFromBytes((*C.uchar)(unsafe.Pointer(&data[0])), C.int(len(data)))
 	if img == nil {
-		return fmt.Errorf("failed to create PixImage from bytes")
+		return fmt.Errorf("failed to create PixImage from bytes: %d", len(data))
 	}
 
 	client.pixImage = img


### PR DESCRIPTION
I've encountered an issue (and seen it in #141) where the `SetImage` and `SetImageFromBytes` methods return a nil error, but the `pixImage` set on the client is nil. Later on when you run `client.Text()` you see an error saying that the PixImage is not set, which feels misleading.

Perhaps there are some cases where you want the user to be able to set the image to nil, in which case this isn't needed, but from the looks of it this appears unintended.