### PR TITLE
refactor: add a finalizer to close the client

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/xml"
 	"image"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,6 +45,12 @@ func TestNewClient(t *testing.T) {
 	defer client.Close()
 
 	Expect(t, client).TypeOf("*gosseract.Client")
+}
+
+func TestDoubleClose(t *testing.T) {
+	client := NewClient()
+	client.Close()
+	client.Close()
 }
 
 func TestClient_SetTessdataPrefix(t *testing.T) {
@@ -127,7 +132,7 @@ func TestClient_SetImageFromBytes(t *testing.T) {
 	client := NewClient()
 	defer client.Close()
 
-	content, err := ioutil.ReadFile("./test/data/001-helloworld.png")
+	content, err := os.ReadFile("./test/data/001-helloworld.png")
 	if err != nil {
 		t.Fatalf("could not read test file")
 	}

--- a/all_test.go
+++ b/all_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"image"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -132,7 +133,7 @@ func TestClient_SetImageFromBytes(t *testing.T) {
 	client := NewClient()
 	defer client.Close()
 
-	content, err := os.ReadFile("./test/data/001-helloworld.png")
+	content, err := ioutil.ReadFile("./test/data/001-helloworld.png")
 	if err != nil {
 		t.Fatalf("could not read test file")
 	}

--- a/client.go
+++ b/client.go
@@ -85,8 +85,11 @@ func NewClient() *Client {
 
 // Close frees allocated API. This MUST be called for ANY client constructed by "NewClient" function.
 func (client *Client) Close() (err error) {
+	// no need for a finalizer anymore
+	runtime.SetFinalizer(client, nil)
 	if client.api == nil {
-		return nil // already closed or not constructed
+		// already closed or not constructed
+		return nil
 	}
 	// defer func() {
 	// 	if e := recover(); e != nil {
@@ -102,8 +105,6 @@ func (client *Client) Close() (err error) {
 		C.DestroyPixImage(client.pixImage)
 		client.pixImage = nil
 	}
-	// no need for a finalizer anymore
-	runtime.SetFinalizer(client, nil)
 	return err
 }
 


### PR DESCRIPTION
Reference: #245

Different from the previous PR, this PR adds client checks to all exposed methods to make the behavior of all methods consistent.
