### PR TITLE
ci: bump the version of actions/setup-go and actions/checkout

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -19,9 +19,9 @@ jobs:
     name: macOS Go${{ matrix.go }} on ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
       - name: Install tesseract
@@ -36,9 +36,9 @@ jobs:
     needs: macos
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: '1.18'
       - name: Install packages

--- a/.github/workflows/runtime-docker.yml
+++ b/.github/workflows/runtime-docker.yml
@@ -27,7 +27,7 @@ jobs:
     name: Docker ${{ matrix.runtime }}
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: ${{ matrix.runtime }}
         shell: 'script -q -e -c "bash {0}"'
         run: bash ./test/runtime --driver docker --build --run ${{ matrix.runtime }}
@@ -36,7 +36,7 @@ jobs:
     name: Test Dockerfile on the repo root
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build
         run: docker build . -t otiai10/gosseract
       - name: Test Run

--- a/.github/workflows/runtime-vagrant.yml
+++ b/.github/workflows/runtime-vagrant.yml
@@ -22,6 +22,6 @@ jobs:
     name: Vagrant ${{ matrix.runtime }}
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: ${{ matrix.runtime }}
         run: bash ./test/runtime --driver vagrant --build --run ${{ matrix.runtime }}

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -18,9 +18,9 @@ jobs:
     name: Windows Test
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: 1.18
     - name: Install Tesseract


### PR DESCRIPTION
The old versions of actions/setup-go and actions/checkout are running on `Node.js` v16 which is going to be deprecated in GitHub Actions runner (https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/). Bump the versions of them to use `Node.js` v20.