### PR TITLE
Add instruction and docker example for static build

### DIFF
--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -1,0 +1,65 @@
+#####
+# This is an example to showcase how to build a statically linked binary
+# of your go project which uses gosseract.
+# The below steps only support the use of PNG files, read the instruction
+# on each step to use other formats.
+#####
+
+FROM ubuntu:latest AS build-stage
+
+# Build tools and dependencies
+
+# To use other file types, you need to include their library.
+# Example: PNG requires libpng-dev and xz-utils.
+
+# To use other languages than English, add their traineddata below.
+RUN apt-get update
+RUN apt-get install -y \
+  g++-10 autoconf make git golang libtool pkg-config \
+  xz-utils libpng-dev \
+  tesseract-ocr-eng
+
+
+# Leptonica static build ( required for tesseract )
+
+# To use other file types, you need to remove the disable flag
+# for that filetype. Example: remove '--without-jpeg' to use JPEG images.
+WORKDIR /build/leptonica
+RUN git clone --depth 1 https://github.com/DanBloomberg/leptonica.git .
+RUN ./autogen.sh
+RUN ./configure '--with-pic' '--disable-shared' '--without-zlib' '--without-jpeg' '--without-libtiff' '--without-giflib' '--without-libwebp' '--without-libwebpmux' '--without-libopenjpeg' '--disable-programs' 'CXX=g++-10' 'CFLAGS=-D DEFAULT_SEVERITY=L_SEVERITY_ERROR -g0 -O3'
+RUN make 
+RUN make install
+
+
+# Tesseract static build
+WORKDIR /build/tesseract
+RUN git clone --depth 1 https://github.com/tesseract-ocr/tesseract.git .
+RUN ./autogen.sh
+RUN ./configure '--with-pic' '--disable-shared' '--disable-legacy' '--disable-graphics' '--disable-openmp' '--without-curl' '--without-archive' '--disable-doc' 'CXX=g++-10' 'CXXFLAGS=-DTESS_EXPORTS -g0 -O3 -ffast-math'
+RUN make
+RUN make install
+
+
+# App static build
+WORKDIR /build/app
+COPY . .
+
+# To user other file types, add their library flags.
+# Example: PNG requires -lpng and -lz.
+RUN CGO_ENABLED=1 GOOS=linux \
+    go build  -a -tags netgo -ldflags '-extldflags "-static -L/usr/local/lib -ltesseract -lleptonica -lpng -lz"' ./app.go
+
+
+FROM scratch
+
+# Binaries
+COPY --from=build-stage /build/app/app /app
+
+# Tesseract traineddata
+
+# To use other language, include their traineddata below
+COPY --from=build-stage /usr/share/tesseract-ocr/5/tessdata/eng.traineddata /usr/local/share/tessdata/eng.traineddata
+
+
+CMD ["/app"]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ func main() {
 Please check this [Dockerfile](https://github.com/otiai10/gosseract/blob/main/Dockerfile) to get started step-by-step.
 Or if you want the env instantly, you can just try by `docker run -it --rm otiai10/gosseract`.
 
+# Statically linked go build
+
+[Gosseract](https://github.com/otiai10/gosseract) uses the native C api to use tesseract. To build a statically linked go binary, you have to first build both tesseract and leptonica statically. Checkout the [Dockerfile.static](https://github.com/otiai10/gosseract/blob/main/Dockerfile.static) file for step-by-step instructions. The same steps can also be followed in Ubuntu.
+
 # Test
 
 In case you have [tesseract-ocr](https://github.com/tesseract-ocr/tessdoc) on your local, you can just hit


### PR DESCRIPTION
Adds a Dockerfile showcasing how to make a statically linked binary of a go project which uses Gosseract.