### PR TITLE
Add GetOrientation

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -163,7 +163,6 @@ func TestClient_SetImageFromBytes(t *testing.T) {
 }
 
 func TestClient_SetWhitelist(t *testing.T) {
-
 	if os.Getenv("TESS_LSTM_DISABLED") == "1" {
 		t.Skip("Whitelist with LSTM is not working for now. Please check https://github.com/tesseract-ocr/tesseract/issues/751")
 	}
@@ -183,7 +182,6 @@ func TestClient_SetWhitelist(t *testing.T) {
 }
 
 func TestClient_SetBlacklist(t *testing.T) {
-
 	if os.Getenv("TESS_LSTM_DISABLED") == "1" {
 		t.Skip("Blacklist with LSTM is not working for now. Please check https://github.com/tesseract-ocr/tesseract/issues/751")
 	}
@@ -218,7 +216,6 @@ func TestClient_SetLanguage(t *testing.T) {
 }
 
 func TestClient_ConfigFilePath(t *testing.T) {
-
 	if os.Getenv("TESS_LSTM_DISABLED") == "1" {
 		t.Skip("Whitelist with LSTM is not working for now. Please check https://github.com/tesseract-ocr/tesseract/issues/751")
 	}
@@ -243,11 +240,9 @@ func TestClient_ConfigFilePath(t *testing.T) {
 		err := client.SetConfigFile("./test/config/02.config")
 		Expect(t, err).Not().ToBe(nil)
 	})
-
 }
 
 func TestClientBoundingBox(t *testing.T) {
-
 	if os.Getenv("TESS_BOX_DISABLED") == "1" {
 		t.Skip()
 	}
@@ -279,8 +274,22 @@ func TestClientBoundingBox(t *testing.T) {
 	}
 }
 
-func TestClient_HTML(t *testing.T) {
+func TestClient_GetOrientation(t *testing.T) {
+	client := NewClient()
+	defer client.Close()
+	client.SetImage("./test/data/003-longer-text.png")
 
+	o, err := client.GetOrientation()
+	Expect(t, err).ToBe(nil)
+	Expect(t, o).ToBe(Orientation{
+		page:         ORIENTATION_PAGE_UP,
+		writing:      WRITING_DIRECTION_LEFT_TO_RIGHT,
+		line:         TEXTLINE_ORDER_TOP_TO_BOTTOM,
+		deskew_angle: 0.0,
+	})
+}
+
+func TestClient_HTML(t *testing.T) {
 	if os.Getenv("TESS_BOX_DISABLED") == "1" {
 		t.Skip()
 	}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -37,3 +37,12 @@ func BenchmarkClient_GetBoundingBoxesVerbose(b *testing.B) {
 		client.Close()
 	}
 }
+
+func BenchmarkClient_GetOrientation(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		client := NewClient()
+		client.SetImage("./test/data/003-longer-text.png")
+		client.GetOrientation()
+		client.Close()
+	}
+}

--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ package gosseract
 // #include <stdbool.h>
 // #include "tessbridge.h"
 import "C"
+
 import (
 	"fmt"
 	"image"
@@ -14,10 +15,8 @@ import (
 	"unsafe"
 )
 
-var (
-	// ErrClientNotConstructed is returned when a client is not constructed
-	ErrClientNotConstructed = fmt.Errorf("TessBaseAPI is not constructed, please use `gosseract.NewClient`")
-)
+// ErrClientNotConstructed is returned when a client is not constructed
+var ErrClientNotConstructed = fmt.Errorf("TessBaseAPI is not constructed, please use `gosseract.NewClient`")
 
 // Version returns the version of Tesseract-OCR
 func Version() string {
@@ -119,7 +118,6 @@ func (client *Client) Version() string {
 
 // SetImage sets path to image file to be processed OCR.
 func (client *Client) SetImage(imagepath string) error {
-
 	if client.api == nil {
 		return ErrClientNotConstructed
 	}
@@ -150,7 +148,6 @@ func (client *Client) SetImage(imagepath string) error {
 
 // SetImageFromBytes sets the image data to be processed OCR.
 func (client *Client) SetImageFromBytes(data []byte) error {
-
 	if client.api == nil {
 		return ErrClientNotConstructed
 	}
@@ -265,7 +262,6 @@ func (client *Client) SetTessdataPrefix(prefix string) error {
 
 // Initialize tesseract::TessBaseAPI
 func (client *Client) init() error {
-
 	if !client.shouldInit {
 		C.SetPixImage(client.api, client.pixImage)
 		return nil
@@ -452,6 +448,31 @@ func (client *Client) GetBoundingBoxesVerbose() (out []BoundingBox, err error) {
 		})
 	}
 	return
+}
+
+type Orientation struct {
+	page         PageOrientation
+	writing      WritingDirection
+	line         TextlineOrder
+	deskew_angle float32
+}
+
+func (client *Client) GetOrientation() (Orientation, error) {
+	if client.api == nil {
+		return Orientation{}, ErrClientNotConstructed
+	}
+
+	if err := client.init(); err != nil {
+		return Orientation{}, err
+	}
+
+	o := C.GetOrientation(client.api)
+	return Orientation{
+		page:         PageOrientation(o.page),
+		writing:      WritingDirection(o.writing),
+		line:         TextlineOrder(o.line),
+		deskew_angle: float32(o.deskew_angle),
+	}, nil
 }
 
 // getDataPath is useful hepler to determine where current tesseract

--- a/constant.go
+++ b/constant.go
@@ -57,6 +57,39 @@ const (
 	RIL_SYMBOL
 )
 
+// PageOrientation represents the oritentation of a page and maps
+// directly to enum tesseract::Orientation.
+// See https://github.com/tesseract-ocr/tesseract/blob/f96cb8d9cb6e7958ddaa52cbbb33792b5d111913/include/tesseract/publictypes.h#L114
+type PageOrientation int
+
+const (
+	ORIENTATION_PAGE_UP PageOrientation = iota
+	ORIENTATION_PAGE_RIGHT
+	ORIENTATION_PAGE_DOWN
+	ORIENTATION_PAGE_LEFT
+)
+
+// WritingDirection represents the direction in which grapheme clusters
+// within a line of text are laid out logically. Maps directly to enum
+// tesseract::WritingDirection. See https://github.com/tesseract-ocr/tesseract/blob/f96cb8d9cb6e7958ddaa52cbbb33792b5d111913/include/tesseract/publictypes.h#L129
+type WritingDirection int
+
+const (
+	WRITING_DIRECTION_LEFT_TO_RIGHT WritingDirection = iota
+	WRITING_DIRECTION_RIGHT_TO_LEFT
+	WRITING_DIRECTION_TOP_TO_BOTTOM
+)
+
+// TextlineOrder represents the sequence in which lines are read. Maps
+// directly to tesseract::TextlineOrder. See https://github.com/tesseract-ocr/tesseract/blob/f96cb8d9cb6e7958ddaa52cbbb33792b5d111913/include/tesseract/publictypes.h#L146
+type TextlineOrder int
+
+const (
+	TEXTLINE_ORDER_LEFT_TO_RIGHT TextlineOrder = iota
+	TEXTLINE_ORDER_RIGHT_TO_LEFT
+	TEXTLINE_ORDER_TOP_TO_BOTTOM
+)
+
 // SettableVariable represents available strings for TessBaseAPI::SetVariable.
 // See https://groups.google.com/forum/#!topic/tesseract-ocr/eHTBzrBiwvQ
 // and https://github.com/tesseract-ocr/tesseract/blob/master/src/ccmain/tesseractclass.h

--- a/tessbridge.cpp
+++ b/tessbridge.cpp
@@ -202,6 +202,22 @@ bounding_boxes* GetBoundingBoxes(TessBaseAPI a, int pageIteratorLevel) {
     return box_array;
 }
 
+orientation GetOrientation(TessBaseAPI a) {
+    tesseract::TessBaseAPI *api = (tesseract::TessBaseAPI *)a;
+    tesseract::Orientation page;
+    tesseract::WritingDirection writing;
+    tesseract::TextlineOrder line;
+    float deskew_angle;
+    tesseract::PageIterator *it = api->AnalyseLayout();
+    it->Orientation(&page, &writing, &line, &deskew_angle);
+    orientation o = {.page = page,
+                     .writing = writing,
+                     .line = line,
+                     .deskew_angle = deskew_angle};
+    delete it;
+    return o;
+}
+
 const char* Version(TessBaseAPI a) {
     tesseract::TessBaseAPI* api = (tesseract::TessBaseAPI*)a;
     const char* v = api->Version();

--- a/tessbridge.h
+++ b/tessbridge.h
@@ -17,6 +17,13 @@ struct bounding_boxes {
     struct bounding_box* boxes;
 };
 
+struct orientation {
+    int page;
+    int writing;
+    int line;
+    float deskew_angle;
+};
+
 TessBaseAPI Create(void);
 
 void Free(TessBaseAPI);
@@ -25,6 +32,7 @@ void ClearPersistentCache(TessBaseAPI);
 int Init(TessBaseAPI, char*, char*, char*, char*);
 struct bounding_boxes* GetBoundingBoxes(TessBaseAPI, int);
 struct bounding_boxes* GetBoundingBoxesVerbose(TessBaseAPI);
+struct orientation GetOrientation(TessBaseAPI);
 bool SetVariable(TessBaseAPI, char*, char*);
 void SetPixImage(TessBaseAPI a, PixImage pix);
 void SetPageSegMode(TessBaseAPI, int);


### PR DESCRIPTION
Adds a `GetOrientation` method to the client that performs orientation and script detection (OSD). See the Orientation example in the [API-Examples](https://tesseract-ocr.github.io/tessdoc/APIExample.html).